### PR TITLE
ADM remediating 2 vulnerabilities

### DIFF
--- a/plugins/google-analytics/assemblies/plugin/pom.xml
+++ b/plugins/google-analytics/assemblies/plugin/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>2.1.1</version>
+      <version>2.1.2</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/plugins/google-analytics/core/pom.xml
+++ b/plugins/google-analytics/core/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>2.1.1</version>
+      <version>2.1.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.oauth-client</groupId>

--- a/plugins/pentaho-googledrive-vfs/core/pom.xml
+++ b/plugins/pentaho-googledrive-vfs/core/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20230306-2.0.0</version>
+            <version>v3-rev20230413-2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.http-client</groupId>


### PR DESCRIPTION
Vulnerabilities:
* -: com.jayway.jsonpath:json-path:2.5.0
* CVE-2021-27568, CVE-2023-1370: net.minidev:json-smart:2.3
* -: com.google.api-client:google-api-client:2.1.1
* -: com.google.apis:google-api-services-drive:v3-rev20230306-2.0.0
* -: com.google.api-client:google-api-client:2.1.1

Dependencies upgraded:
* com.google.api-client:google-api-client:2.1.1 -> 2.1.2
* com.google.api-client:google-api-client:2.1.1 -> 2.1.2
* com.google.apis:google-api-services-drive:v3-rev20230306-2.0.0 -> v3-rev20230413-2.0.0
* com.jayway.jsonpath:json-path:2.5.0 -> 2.8.0
* net.minidev:json-smart:2.3 -> 2.4.9

Auto-merge is enabled