### PR TITLE
ADM remediating 2 vulnerabilities

### DIFF
--- a/plugins/google-analytics/assemblies/plugin/pom.xml
+++ b/plugins/google-analytics/assemblies/plugin/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>2.1.3</version>
+      <version>2.1.4</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/plugins/google-analytics/core/pom.xml
+++ b/plugins/google-analytics/core/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>2.1.3</version>
+      <version>2.1.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.oauth-client</groupId>


### PR DESCRIPTION
Vulnerabilities:
* -: com.jayway.jsonpath:json-path:2.5.0
* CVE-2021-27568, CVE-2023-1370: net.minidev:json-smart:2.3
* -: com.google.api-client:google-api-client:2.1.3
* -: com.google.api-client:google-api-client:2.1.3

Dependencies upgraded:
* com.google.api-client:google-api-client:2.1.3 -> 2.1.4
* com.google.api-client:google-api-client:2.1.3 -> 2.1.4
* com.jayway.jsonpath:json-path:2.5.0 -> 2.8.0
* net.minidev:json-smart:2.3 -> 2.4.9

Auto-merge is enabled